### PR TITLE
No Server Particles

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -187,6 +187,18 @@ if Config.Components.AntiWeapons then
         end
     end)
 end
+if Config.NoParticles then
+	Citizen.CreateThread(function ()
+    		while true do
+			local xpos = 0.0
+			local ypos = 0.0
+			local zpos = 0.0
+			local radio = 5000000000000.0
+			RemoveParticleFxInRange(xpos, ypos, zpos, radio) -- Removes all Server Particles
+		Citizen.Wait(0)
+    		end
+	end)
+end
 
 isStaff = false;
 RegisterNetEvent('Anticheat:CheckStaffReturn')


### PR DESCRIPTION
Cheaters seem to have found a way to do explosion and firework/particle shows without being detected, so this "fix" deletes all the particles from the server.